### PR TITLE
Fix Security Alert

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,2 @@
-aniso8601==3.0.2
-Django==2.1.5
-graphene==2.1.3
-graphene-django==2.2.0
-graphql-core==2.1
-graphql-relay==0.4.5
-iso8601==0.1.12
-promise==2.2.1
-pytz==2018.7
-Rx==1.6.1
-singledispatch==3.4.0.3
-six==1.11.0
-typing==3.6.6
+graphene>=2.0
+graphene-django>=2.0


### PR DESCRIPTION
just remove the extra dependencies and mark essential dependencies with `gte` symbols